### PR TITLE
create targetfolder, use getpass for input

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -318,7 +318,11 @@ def get_key():
     rounds = 2048
     keysize = 256
 
-    mnemonic = getpass.getpass("Please enter mnemonic: ").encode()
+    vis = input("Should mnemonic be visible while typing? [y/n]: ")
+    if vis.lower().startswith("y"):
+        mnemnonic = input("Please enter mnemonic: ").encode()
+    else:
+        mnemonic = getpass.getpass("Please enter mnemonic: ").encode()
     key = hashlib.pbkdf2_hmac("sha512", mnemonic, salt, rounds)
     return key[:keysize//8]
 

--- a/parse.py
+++ b/parse.py
@@ -2,6 +2,7 @@
 import re
 import os
 import sys
+import getpass
 import glob
 import string
 import struct
@@ -135,6 +136,9 @@ def parse_metadata(backupfolder, targetfolder, key):
 
 # parses everything
 def parse_backup(backupfolder, targetfolder, key):
+    if targetfolder:
+        os.mkdirs(targetfolder)
+    
     parse_metadata(backupfolder, targetfolder, key)
     parse_apk_backup(backupfolder)
 
@@ -314,7 +318,7 @@ def get_key():
     rounds = 2048
     keysize = 256
 
-    mnemonic = input("Please enter mnemonic: ").encode()
+    mnemonic = getpass.getpass("Please enter mnemonic: ").encode()
     key = hashlib.pbkdf2_hmac("sha512", mnemonic, salt, rounds)
     return key[:keysize//8]
 


### PR DESCRIPTION
if `decrypt` command is called when the targetfolder doesn't exist, it causes an error

also, using getpass will prevent the user's mnemonic from ending up in their terminal logs